### PR TITLE
Add support of hidden input

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@ dist
 # Misc
 .DS_Store
 .vscode
+.idea
 .npmrc
 tsconfig.tsbuildinfo
-
-

--- a/src/FocusError.tsx
+++ b/src/FocusError.tsx
@@ -43,20 +43,28 @@ export function FocusError({
       }, [] as string[]);
 
       if (errorNames.length && typeof document !== "undefined") {
-        let errorElement: HTMLElement | null;
+        let errorElement: HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement | null = null;
+        let errorNameIndex = 0;
 
-        errorNames.forEach((errorKey) => {
-          const selector = `[name="${errorKey}"]`;
-          if (!errorElement) {
-            errorElement = document.querySelector(selector);
-            return;
-          }
-        });
+        while (errorNameIndex < errorNames.length && !errorElement) {
+          errorElement = document.querySelector(`[name="${errorNames[errorNameIndex++]}"]`);
+        }
 
         // This is to avoid the other components autofocus when submitting
         setTimeout(() => {
-          errorElement && errorElement.focus();
-          onFocus && onFocus()
+          if (errorElement) {
+            if (errorElement.type === 'hidden') {
+              errorElement.parentElement?.scrollIntoView({
+                block: 'center',
+              });
+            } else {
+              errorElement.focus();
+            }
+          }
+
+          if (onFocus) {
+            onFocus();
+          }
         }, focusDelay);
       }
     }


### PR DESCRIPTION
It is a very common use case when there is a custom control on the form. For example, custom select component which uses `<input type="hidden">` under the hood.
Since hidden input does not support focusing, I decided to scroll to its parent.